### PR TITLE
Adding JIRA webhook to PR approved transition

### DIFF
--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -5,6 +5,8 @@ import {QAStatus} from "./model/QAStatus.js";
 const core = require('@actions/core');
 const github = require('@actions/github');
 
+let JIRA_PR_APPROVED_WEBHOOK = "https://automation.atlassian.com/pro/hooks/99c04c3891fa359e13d70428baf503c520256ab9"
+
 export async function run() {
     try {
         const token = core.getInput("repo-token", { required: true });
@@ -58,6 +60,7 @@ async function getApprovalStatus(client, prNumber) {
     let changesRequested = activeChangeRequests.length > 0
 
     if (approved && !changesRequested) {
+        sendMessage(JIRA_PR_APPROVED_WEBHOOK)
         return ApprovalStatus.APPROVED
     } else if (changesRequested) {
         return ApprovalStatus.CHANGES_REQUESTED
@@ -145,3 +148,19 @@ async function removeLabels(client, prNumber, labels) {
         })
     )
 }
+
+function sendMessage(webhook, requestType = "POST") {
+    const pullRequest = github.context.payload.pull_request
+    if (!pullRequest) { return undefined; }
+
+    var request = new XMLHttpRequest();
+    request.open(requestType, webhook);
+
+    request.setRequestHeader('Content-type', 'application/json');
+
+    var body = {
+        "pr_content": pullRequest.body,
+        "pr_title": pullRequest.title,
+        "branch_name": pullRequest.head.ref
+        }
+    }

--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -115,7 +115,7 @@ async function updateLabels(client, prNumber, newLabels, currentLabels) {
         return currentLabels.includes(label.name) && !(newLabels.includes(label.name))
     })
 
-    if (labelsToAdd == labelsToAdd.filter(label => label == "Ready for QA")) {
+    if (labelsToAdd == labelsToAdd.includes("Ready for QA")) {
         sendMessage(JIRA_PR_APPROVED_WEBHOOK)
     }
 
@@ -167,6 +167,6 @@ function sendMessage(webhook, requestType = "POST") {
         "branch_name": pullRequest.head.ref
       }
 
-      console.log(Sending message ${body})
+      console.log(`Sending message ${body}`)
       return request.send(JSON.stringify(body));
 }


### PR DESCRIPTION
Goal - push to a JIRA webhook and notify JIRA on PR state 

current changes (should) alert JIRA when a PR has been approved and is ready for QA, so JIRA can update the ticket accordingly